### PR TITLE
fix: Mistake in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use the `SwipeableCardsSection` widget provided by the package
       body: Column(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          SwipeableCardSectionController(
+          SwipeableCardsSection(
             cardController: _cardController,
             context: context,
             //add the first 3 cards (widgets)


### PR DESCRIPTION
You have a mistake in your documentation. The correct widget name is `SwipeableCardsSection` and you have the `SwipeableCardsSectionController`. I got confused after reading the documentation on [pub.dev](https://pub.dev/packages/swipeable_card_stack), that's why I opened this PR.