### PR TITLE
fix: dispose AnimationController upon disposal of SwipeableCardsSection

### DIFF
--- a/lib/swipeable_card_stack.dart
+++ b/lib/swipeable_card_stack.dart
@@ -107,6 +107,13 @@ class _CardsSectionState extends State<SwipeableCardsSection>
   }
 
   @override
+  void dispose() {
+    _controller.dispose();
+
+    super.dispose();
+  }
+
+  @override
   void initState() {
     super.initState();
 


### PR DESCRIPTION
In some cases, disposal of a `SwipeableCardsSection` leaks an active `Ticker` due to the `SingleTickerProviderStateMixin` in `_CardsSectionState`. This can be fixed simply by disposing the AnimationController upon Widget disposal.

The error:

> ══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following assertion was thrown while finalizing the widget tree:
_CardsSectionState#cde08(ticker active) was disposed with an active Ticker.
_CardsSectionState created a Ticker via its SingleTickerProviderStateMixin, but at the time
dispose() was called on the mixin, that Ticker was still active. The Ticker must be disposed before
calling super.dispose().
Tickers used by AnimationControllers should be disposed by calling dispose() on the
AnimationController itself. Otherwise, the ticker will leak.